### PR TITLE
Finished addressing bug #9

### DIFF
--- a/AspNetCore.Identity.CosmosDb.Example/AspNetCore.Identity.CosmosDb.Example.csproj
+++ b/AspNetCore.Identity.CosmosDb.Example/AspNetCore.Identity.CosmosDb.Example.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <Version>2.0.19.1</Version>
-    <AssemblyVersion>2.0.19.1</AssemblyVersion>
-    <FileVersion>2.0.19.1</FileVersion>
+    <Version>2.0.20.1</Version>
+    <AssemblyVersion>2.0.20.1</AssemblyVersion>
+    <FileVersion>2.0.20.1</FileVersion>
     <Authors>Eric Kauffman</Authors>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-AspNetCore.Identity.CosmosDb.Example-0017CFC3-2699-4172-8E2A-2D5B89D0E0D1</UserSecretsId>
@@ -18,16 +18,16 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.Identity.Services.SendGrid" Version="2.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.9" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspNetCore.Identity.CosmosDb.Tests/AspNetCore.Identity.CosmosDb.Tests.csproj
+++ b/AspNetCore.Identity.CosmosDb.Tests/AspNetCore.Identity.CosmosDb.Tests.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <Version>2.0.19.1</Version>
-    <AssemblyVersion>2.0.19.1</AssemblyVersion>
-    <FileVersion>2.0.19.1</FileVersion>
+    <Version>2.0.20.1</Version>
+    <AssemblyVersion>2.0.20.1</AssemblyVersion>
+    <FileVersion>2.0.20.1</FileVersion>
     <Authors>Eric Kauffman</Authors>
     <IsPackable>false</IsPackable>
 
@@ -14,13 +14,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />

--- a/AspNetCore.Identity.CosmosDb.Tests/Stores/CosmosUserStoreTests.cs
+++ b/AspNetCore.Identity.CosmosDb.Tests/Stores/CosmosUserStoreTests.cs
@@ -698,5 +698,21 @@ namespace AspNetCore.Identity.CosmosDb.Stores.Tests
             Assert.IsTrue(result.Count > 0);
         }
 
+        [TestMethod()]
+        public async Task SetAndGetAuthenticatorKeyAsyncTest()
+        {
+            // Arrange
+            using var userStore = _testUtilities.GetUserStore();
+            var user = await GetMockRandomUserAsync(userStore);
+
+            // Act
+            var loginInfo = GetMockLoginInfoAsync();
+            await userStore.AddLoginAsync(user, loginInfo);
+            await userStore.SetAuthenticatorKeyAsync(user, "AuthenticatorKey", default);
+            var code = await userStore.GetAuthenticatorKeyAsync(user, default);
+
+            // Assert
+            Assert.IsNotNull(code);
+        }
     }
 }

--- a/AspNetCore.Identity.CosmosDb/AspNetCore.Identity.CosmosDb.csproj
+++ b/AspNetCore.Identity.CosmosDb/AspNetCore.Identity.CosmosDb.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>2.0.19-rc</Version>
-    <AssemblyVersion>2.0.19.1</AssemblyVersion>
-    <FileVersion>2.0.19.1</FileVersion>
+    <Version>2.0.20</Version>
+    <AssemblyVersion>2.0.20.1</AssemblyVersion>
+    <FileVersion>2.0.20.1</FileVersion>
     <Authors>toiyabe62</Authors>
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>Cosmos, CosmosDB, Identity, Provider, AspNetCore, Membership, Roles, AspNetCore.Identity, AspNetCore.Identity.CosmosDb, Microsoft.AspNetCore.Identity, aspnet, efcore</PackageTags>
@@ -22,15 +22,15 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Company>Cosmos Software LLC</Company>
     <Copyright>Moonrise Software LLC</Copyright>
-    <PackageReleaseNotes>Updated NuGet packages, readme.md, re-ran unit tests.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed bug #9 (2FA), added unit test for 2FA, updated packages, updated integraton test website for 2FA..</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Duende.IdentityServer.EntityFramework.Storage" Version="6.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="6.0.9" />
+    <PackageReference Include="Duende.IdentityServer.EntityFramework.Storage" Version="6.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="6.0.10" />
   </ItemGroup>
   
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ documentation for more details.
 
 # Changelog
 
-## v2.0.19-rc (Release Candidate)
+## v2.0.20-rc (Release Candidate)
 
 - Addressing [bug #9](https://github.com/CosmosSoftware/AspNetCore.Identity.CosmosDb/issues/9), implemented interfaces IUserAuthenticatorKeyStore and IUserTwoFactorRecoveryCodeStore to support two factor authentication.  Example website updated to demonstrate capability.
 


### PR DESCRIPTION
Bug reported a failure with the UserStore to support "IUserAuthenticatorKeyStore."  Further investigation found that the user store needed to support other interfaces as well.  

The user store now supports these interfaces:

- IUserAuthenticatorKeyStore
- IUserTwoFactorRecoveryCodeStore

A unit test has been added to test setting of the 2FA authentication key value, and integration tests with the example website now have QR Code support to test setting an authenticator app and generating recovery keys.

Also, as a matter of maintenance, Nuget package dependencies have been brought up to date.

-Eric